### PR TITLE
Added z_shieldcoinbase contextual menu option for z-addresses.

### DIFF
--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/AddressTable.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/AddressTable.java
@@ -121,7 +121,7 @@ public class AddressTable
     }
     
     protected JMenuItem instantiateShieldAllCoinbaseMenuItem() {
-        JMenuItem shieldAllCoinbaseFundsMenuItem = new JMenuItem("Shield all coinbase to this z-address");
+        JMenuItem shieldAllCoinbaseFundsMenuItem = new JMenuItem("Shield all coinbases to this z-address");
         //obtainPrivateKey.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, accelaratorKeyMask));
         
         shieldAllCoinbaseFundsMenuItem.addActionListener(new ActionListener()
@@ -166,7 +166,7 @@ public class AddressTable
                         JOptionPane.showMessageDialog(
                                 AddressTable.this.getRootPane().getParent(),
                                 "Coinbase funds in the amount of " + shieldCoinbaseResponse.shieldedValue + " BTCP from " + shieldCoinbaseResponse.shieldedUTXOs + " UTXO" + (shieldCoinbaseResponse.shieldedUTXOs == 1 ? "" : "s") + " were shielded to the following z-address:\n" + address + "\nPlease Refresh to update balances.\n",
-                                "Shield All Coinbase", JOptionPane.INFORMATION_MESSAGE);
+                                "Shield All Coinbases", JOptionPane.INFORMATION_MESSAGE);
 
 						// TODO: trigger refresh of window
 
@@ -177,7 +177,7 @@ public class AddressTable
                                 AddressTable.this.getRootPane().getParent(),
                                 "Error:" + "\n" +
                                         ex.getMessage() + "\n\n",
-                                "Error in shielding all coinbase!",
+                                "Error in shielding all coinbases!",
                                 JOptionPane.ERROR_MESSAGE);
                     }
                 } else

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/AddressTable.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/AddressTable.java
@@ -2,6 +2,7 @@ package org.btcprivate.wallets.fullnode.ui;
 
 
 import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller;
+import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller.ShieldCoinbaseResponse;
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.Util;
 
@@ -21,17 +22,37 @@ import java.awt.event.ActionListener;
 public class AddressTable
         extends DataTable
 {
+
+	protected JPopupMenu zAddressPopupMenu;
+	protected BTCPClientCaller caller;
+
     public AddressTable(final Object[][] rowData, final Object[] columnNames,
                         final BTCPClientCaller caller)
     {
         super(rowData, columnNames);
+        
+        this.caller = caller;
+        
+        // instantiate and do basic setup for popup menu for z-addresses
+        zAddressPopupMenu = new JPopupMenu();
+        zAddressPopupMenu.add(instantiateCopyMenuItem());
+        zAddressPopupMenu.add(instantiateExportToCSVMenuItem());
+        
         int accelaratorKeyMask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
-        JMenuItem obtainPrivateKey = new JMenuItem("Obtain private key");
-        //obtainPrivateKey.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, accelaratorKeyMask));
-        popupMenu.add(obtainPrivateKey);
+        popupMenu.add(instantiateObtainPrivateKeyMenuItem());
+        zAddressPopupMenu.add(instantiateObtainPrivateKeyMenuItem());
+        
+        zAddressPopupMenu.add(instantiateShieldAllCoinbaseMenuItem());
 
-        obtainPrivateKey.addActionListener(new ActionListener()
+
+    } // End constructor
+    
+    protected JMenuItem instantiateObtainPrivateKeyMenuItem() {
+        JMenuItem menuItem = new JMenuItem("Obtain private key");
+        //obtainPrivateKey.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, accelaratorKeyMask));
+        
+        menuItem.addActionListener(new ActionListener()
         {
             @Override
             public void actionPerformed(ActionEvent e)
@@ -42,7 +63,7 @@ public class AddressTable
                     {
                         String address = AddressTable.this.getModel().getValueAt(lastRow, 2).toString();
                         boolean isZAddress = Util.isZAddress(address);
-
+						
                         // Check for encrypted wallet
                         final boolean bEncryptedWallet = caller.isWalletEncrypted();
                         if (bEncryptedWallet)
@@ -96,6 +117,87 @@ public class AddressTable
                 }
             }
         });
-    } // End constructor
+		return menuItem;
+    }
+    
+    protected JMenuItem instantiateShieldAllCoinbaseMenuItem() {
+        JMenuItem shieldAllCoinbaseFundsMenuItem = new JMenuItem("Shield all coinbase to this z-address");
+        //obtainPrivateKey.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, accelaratorKeyMask));
+        
+        shieldAllCoinbaseFundsMenuItem.addActionListener(new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e)
+            {
+                if ((lastRow >= 0) && (lastColumn >= 0))
+                {
+                    try
+                    {
+                        String address = AddressTable.this.getModel().getValueAt(lastRow, 2).toString();
+                        boolean isZAddress = Util.isZAddress(address);
 
+						if (!isZAddress) {
+							// TODO: this should never happen- gracefully error out
+							return;
+						}
+                        // Check for encrypted wallet
+                        final boolean bEncryptedWallet = caller.isWalletEncrypted();
+                        if (bEncryptedWallet)
+                        {
+                            PasswordDialog pd = new PasswordDialog((JFrame)(AddressTable.this.getRootPane().getParent()));
+                            pd.setVisible(true);
+
+                            if (!pd.isOKPressed())
+                            {
+                                return;
+                            }
+
+                            caller.unlockWallet(pd.getPassword());
+                        }
+
+						ShieldCoinbaseResponse shieldCoinbaseResponse = caller.shieldCoinbase("*", address);
+
+                        // Lock the wallet again
+                        if (bEncryptedWallet)
+                        {
+                            caller.lockWallet();
+                        }
+
+                        JOptionPane.showMessageDialog(
+                                AddressTable.this.getRootPane().getParent(),
+                                "Coinbase funds in the amount of " + shieldCoinbaseResponse.shieldedValue + " BTCP from " + shieldCoinbaseResponse.shieldedUTXOs + " UTXO" + (shieldCoinbaseResponse.shieldedUTXOs == 1 ? "" : "s") + " were shielded to the following z-address:\n" + address + "\nPlease Refresh to update balances.\n",
+                                "Shield All Coinbase", JOptionPane.INFORMATION_MESSAGE);
+
+						// TODO: trigger refresh of window
+
+                    } catch (Exception ex)
+                    {
+                        Log.error("Unexpected error: ", ex);
+                        JOptionPane.showMessageDialog(
+                                AddressTable.this.getRootPane().getParent(),
+                                "Error:" + "\n" +
+                                        ex.getMessage() + "\n\n",
+                                "Error in shielding all coinbase!",
+                                JOptionPane.ERROR_MESSAGE);
+                    }
+                } else
+                {
+                    // Log perhaps
+                }
+            }
+        });
+		return shieldAllCoinbaseFundsMenuItem;
+    }
+    @Override
+	protected JPopupMenu getPopupMenu(int row, int column) 
+	{
+	    String address = AddressTable.this.getModel().getValueAt(row, 2).toString();
+        boolean isZAddress = Util.isZAddress(address);
+		if (isZAddress) 
+		{
+			return zAddressPopupMenu;
+		}
+		return popupMenu;
+	}
+	
 }

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/DataTable.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/DataTable.java
@@ -28,9 +28,9 @@ public class DataTable
 {
     protected int lastRow = -1;
     protected int lastColumn = -1;
-
+    
     protected JPopupMenu popupMenu;
-
+    
     public DataTable(final Object[][] rowData, final Object[] columnNames)
     {
         super(rowData, columnNames);
@@ -43,53 +43,8 @@ public class DataTable
         popupMenu = new JPopupMenu();
         int accelaratorKeyMask = Toolkit.getDefaultToolkit ().getMenuShortcutKeyMask();
 
-        JMenuItem copy = new JMenuItem("Copy value");
-        popupMenu.add(copy);
-        //copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, accelaratorKeyMask));
-        copy.addActionListener(new ActionListener()
-        {
-            @Override
-            public void actionPerformed(ActionEvent e)
-            {
-                if ((lastRow >= 0) && (lastColumn >= 0))
-                {
-                    String text = DataTable.this.getValueAt(lastRow, lastColumn).toString();
-
-                    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-                    clipboard.setContents(new StringSelection(text), null);
-                } else
-                {
-                    // Log perhaps
-                }
-            }
-        });
-
-
-        JMenuItem exportToCSV = new JMenuItem("Export data to CSV");
-        popupMenu.add(exportToCSV);
-        //exportToCSV.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V, accelaratorKeyMask));
-        exportToCSV.addActionListener(new ActionListener()
-        {
-            @Override
-            public void actionPerformed(ActionEvent e)
-            {
-                try
-                {
-                    DataTable.this.exportToCSV();
-                } catch (Exception ex)
-                {
-                    Log.error("Unexpected error: ", ex);
-                    // TODO: better error handling
-                    JOptionPane.showMessageDialog(
-                            DataTable.this.getRootPane().getParent(),
-                            "An unexpected error occurred when exporting data to a CSV file.\n" +
-                                    "\n" +
-                                    ex.getMessage(),
-                            "Error Exporting CSV", JOptionPane.ERROR_MESSAGE);
-                }
-            }
-        });
-
+        popupMenu.add(instantiateCopyMenuItem());
+        popupMenu.add(instantiateExportToCSVMenuItem());
 
         this.addMouseListener(new MouseAdapter()
         {
@@ -106,7 +61,7 @@ public class DataTable
                         table.changeSelection(lastRow, lastColumn, false, false);
                     }
 
-                    popupMenu.show(e.getComponent(), e.getPoint().x, e.getPoint().y);
+                    getPopupMenu(lastRow, lastColumn).show(e.getComponent(), e.getPoint().x, e.getPoint().y);
                     e.consume();
                 } else
                 {
@@ -147,7 +102,60 @@ public class DataTable
         return false;
     }
 
+	protected JPopupMenu getPopupMenu(int row, int column) 
+	{
+		return popupMenu;
+	}
+	
+	protected JMenuItem instantiateCopyMenuItem() {
+		JMenuItem menuItem = new JMenuItem("Copy value");
+        //copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, accelaratorKeyMask));
+        menuItem.addActionListener(new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e)
+            {
+                if ((lastRow >= 0) && (lastColumn >= 0))
+                {
+                    String text = DataTable.this.getValueAt(lastRow, lastColumn).toString();
 
+                    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    clipboard.setContents(new StringSelection(text), null);
+                } else
+                {
+                    // Log perhaps
+                }
+            }
+        });
+        return menuItem;
+	}
+	
+	protected JMenuItem instantiateExportToCSVMenuItem() {
+        JMenuItem menuItem = new JMenuItem("Export data to CSV");
+        //exportToCSV.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V, accelaratorKeyMask));
+        menuItem.addActionListener(new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e)
+            {
+                try
+                {
+                    DataTable.this.exportToCSV();
+                } catch (Exception ex)
+                {
+                    Log.error("Unexpected error: ", ex);
+                    // TODO: better error handling
+                    JOptionPane.showMessageDialog(
+                            DataTable.this.getRootPane().getParent(),
+                            "An unexpected error occurred when exporting data to a CSV file.\n" +
+                                    "\n" +
+                                    ex.getMessage(),
+                            "Error Exporting CSV", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        });
+		return menuItem;
+	}
     // Exports the table data to a CSV file
     private void exportToCSV()
             throws IOException

--- a/src/main/java/org/btcprivate/wallets/fullnode/util/Util.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/util/Util.java
@@ -320,7 +320,8 @@ public class Util
     public static boolean isZAddress(String address)
     {
         return (address != null) &&
-                address.startsWith("zk") &&
+                (address.startsWith("zk")) &&
+//                (address.startsWith("zk") || address.startsWith("zz") || address.startsWith("zt")) &&
                 (address.length() > 40);
     }
 


### PR DESCRIPTION
The contextual menu for z-addresses listed in the "My Addresses" tab now features a menu option, "Shield all coinbase to this z-address"; upon option selection, the wallet UI will display a text response that confirms how much coinbase funds from however many UTXOs were successfully shielded to that z-address.