### PR TITLE
Removed UTF8 BOM from string value whenever it is captured from a text field via getText()

### DIFF
--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/CreateGroupDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/CreateGroupDialog.java
@@ -2,6 +2,7 @@ package org.btcprivate.wallets.fullnode.messaging;
 
 import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller;
 import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller.WalletCallException;
+import org.btcprivate.wallets.fullnode.ui.WalletTextField;
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.StatusUpdateErrorReporter;
 import org.btcprivate.wallets.fullnode.util.Util;
@@ -27,7 +28,7 @@ public class CreateGroupDialog
     protected String  key    = null;
 
     protected JLabel     keyLabel = null;
-    protected JTextField keyField = null;
+    protected WalletTextField keyField = null;
 
     protected JLabel upperLabel;
     protected JLabel lowerLabel;
@@ -70,7 +71,7 @@ public class CreateGroupDialog
         controlsPanel.add(dividerLabel);
 
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        tempPanel.add(keyField = new JTextField(60));
+        tempPanel.add(keyField = new WalletTextField(60));
         controlsPanel.add(tempPanel);
 
         dividerLabel = new JLabel("   ");
@@ -137,7 +138,7 @@ public class CreateGroupDialog
 
     protected void processOK()
     {
-        final String keyPhrase = Util.removeUTF8BOM(CreateGroupDialog.this.keyField.getText());
+        final String keyPhrase = CreateGroupDialog.this.keyField.getText();
 
         if ((keyPhrase == null) || (keyPhrase.trim().length() <= 0))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/CreateGroupDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/CreateGroupDialog.java
@@ -137,7 +137,7 @@ public class CreateGroupDialog
 
     protected void processOK()
     {
-        final String keyPhrase = CreateGroupDialog.this.keyField.getText();
+        final String keyPhrase = Util.removeUTF8BOM(CreateGroupDialog.this.keyField.getText());
 
         if ((keyPhrase == null) || (keyPhrase.trim().length() <= 0))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/IdentityInfoDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/IdentityInfoDialog.java
@@ -20,7 +20,7 @@ public class IdentityInfoDialog
     protected JPanel buttonPanel;
 
     protected WalletTextField nicknameTextField;
-    protected WalletTextArea sendreceiveaddressTextField;
+    protected WalletTextArea sendreceiveaddressTextArea;
     protected WalletTextField senderidaddressTextField;
     protected WalletTextField firstnameTextField;
     protected WalletTextField middlenameTextField;
@@ -65,8 +65,8 @@ public class IdentityInfoDialog
         addFormField(detailsPanel, "Twitter URL:",   twitterTextField = new WalletTextField(40));
 
         addFormField(detailsPanel, "Sender identification B address:", senderidaddressTextField = new WalletTextField(40));
-        addFormField(detailsPanel, "Send/receive Z address:", sendreceiveaddressTextField = new WalletTextArea(2, 40));
-        sendreceiveaddressTextField.setLineWrap(true);
+        addFormField(detailsPanel, "Send/receive Z address:", sendreceiveaddressTextArea = new WalletTextArea(2, 40));
+        sendreceiveaddressTextArea.setLineWrap(true);
 
 
         nicknameTextField.setText(this.identity.getNickname());
@@ -78,7 +78,7 @@ public class IdentityInfoDialog
         facebookTextField.setText(this.identity.getFacebook());
         twitterTextField.setText(this.identity.getTwitter());
         senderidaddressTextField.setText(this.identity.getSenderidaddress());
-        sendreceiveaddressTextField.setText(this.identity.getSendreceiveaddress());
+        sendreceiveaddressTextArea.setText(this.identity.getSendreceiveaddress());
 
         nicknameTextField.setEditable(false);
         firstnameTextField.setEditable(false);
@@ -89,7 +89,7 @@ public class IdentityInfoDialog
         facebookTextField.setEditable(false);
         twitterTextField.setEditable(false);
         senderidaddressTextField.setEditable(false);
-        sendreceiveaddressTextField.setEditable(false);
+        sendreceiveaddressTextArea.setEditable(false);
 
         detailsPanel.setBorder(BorderFactory.createEtchedBorder(EtchedBorder.LOWERED));
         this.getContentPane().add(detailsPanel, BorderLayout.CENTER);

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/IdentityInfoDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/IdentityInfoDialog.java
@@ -6,6 +6,9 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import org.btcprivate.wallets.fullnode.ui.WalletTextArea;
+import org.btcprivate.wallets.fullnode.ui.WalletTextField;
+
 public class IdentityInfoDialog
         extends JDialog
 {
@@ -16,16 +19,16 @@ public class IdentityInfoDialog
 
     protected JPanel buttonPanel;
 
-    protected JTextField nicknameTextField;
-    protected JTextArea sendreceiveaddressTextField;
-    protected JTextField senderidaddressTextField;
-    protected JTextField firstnameTextField;
-    protected JTextField middlenameTextField;
-    protected JTextField surnameTextField;
-    protected JTextField emailTextField;
-    protected JTextField streetaddressTextField;
-    protected JTextField facebookTextField;
-    protected JTextField twitterTextField;
+    protected WalletTextField nicknameTextField;
+    protected WalletTextArea sendreceiveaddressTextField;
+    protected WalletTextField senderidaddressTextField;
+    protected WalletTextField firstnameTextField;
+    protected WalletTextField middlenameTextField;
+    protected WalletTextField surnameTextField;
+    protected WalletTextField emailTextField;
+    protected WalletTextField streetaddressTextField;
+    protected WalletTextField facebookTextField;
+    protected WalletTextField twitterTextField;
 
 
     public IdentityInfoDialog(JFrame parentFrame, MessagingIdentity identity)
@@ -51,18 +54,18 @@ public class IdentityInfoDialog
         JPanel detailsPanel = new JPanel();
         detailsPanel.setLayout(new BoxLayout(detailsPanel, BoxLayout.Y_AXIS));
 
-        addFormField(detailsPanel, "Nickname:",  nicknameTextField = new JTextField(40));
-        addFormField(detailsPanel, "First name:", firstnameTextField = new JTextField(40));
-        addFormField(detailsPanel, "Middle name:", middlenameTextField = new JTextField(40));
-        addFormField(detailsPanel, "Surname:",    surnameTextField = new JTextField(40));
+        addFormField(detailsPanel, "Nickname:",  nicknameTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "First name:", firstnameTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "Middle name:", middlenameTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "Surname:",    surnameTextField = new WalletTextField(40));
 
-        addFormField(detailsPanel, "Email:",         emailTextField = new JTextField(40));
-        addFormField(detailsPanel, "Street address:", streetaddressTextField = new JTextField(40));
-        addFormField(detailsPanel, "Facebook URL:",  facebookTextField = new JTextField(40));
-        addFormField(detailsPanel, "Twitter URL:",   twitterTextField = new JTextField(40));
+        addFormField(detailsPanel, "Email:",         emailTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "Street address:", streetaddressTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "Facebook URL:",  facebookTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "Twitter URL:",   twitterTextField = new WalletTextField(40));
 
-        addFormField(detailsPanel, "Sender identification T address:", senderidaddressTextField = new JTextField(40));
-        addFormField(detailsPanel, "Send/receive Z address:", sendreceiveaddressTextField = new JTextArea(2, 40));
+        addFormField(detailsPanel, "Sender identification T address:", senderidaddressTextField = new WalletTextField(40));
+        addFormField(detailsPanel, "Send/receive Z address:", sendreceiveaddressTextField = new WalletTextArea(2, 40));
         sendreceiveaddressTextField.setLineWrap(true);
 
 

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingOptionsEditDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingOptionsEditDialog.java
@@ -1,5 +1,6 @@
 package org.btcprivate.wallets.fullnode.messaging;
 
+import org.btcprivate.wallets.fullnode.ui.WalletTextField;
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.StatusUpdateErrorReporter;
 import org.btcprivate.wallets.fullnode.util.Util;
@@ -42,8 +43,8 @@ public class MessagingOptionsEditDialog
     protected JLabel infoLabel;
     protected JPanel buttonPanel;
 
-    protected JTextField amountTextField;
-    protected JTextField transactionFeeTextField;
+    protected WalletTextField amountTextField;
+    protected WalletTextField transactionFeeTextField;
     protected JCheckBox automaticallyAddUsers;
 
     public MessagingOptionsEditDialog(JFrame parentFrame, MessagingStorage storage, StatusUpdateErrorReporter errorReporter)
@@ -74,8 +75,8 @@ public class MessagingOptionsEditDialog
 
         addFormField(detailsPanel, "Automatically add users to contact list? ",
                 automaticallyAddUsers = new JCheckBox());
-        addFormField(detailsPanel, "Amount of BTCP to send with every message: ", amountTextField = new JTextField(12));
-        addFormField(detailsPanel, "Transaction fee: ", transactionFeeTextField = new JTextField(12));
+        addFormField(detailsPanel, "Amount of BTCP to send with every message: ", amountTextField = new WalletTextField(12));
+        addFormField(detailsPanel, "Transaction fee: ", transactionFeeTextField = new WalletTextField(12));
 
         DecimalFormatSymbols decSymbols = new DecimalFormatSymbols(Locale.ROOT);
         automaticallyAddUsers.setSelected(options.isAutomaticallyAddUsersIfNotExplicitlyImported());
@@ -106,8 +107,8 @@ public class MessagingOptionsEditDialog
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                    String amountToSend = Util.removeUTF8BOM(MessagingOptionsEditDialog.this.amountTextField.getText());
-                    String transactionFee = Util.removeUTF8BOM(MessagingOptionsEditDialog.this.transactionFeeTextField.getText());
+                    String amountToSend = MessagingOptionsEditDialog.this.amountTextField.getText();
+                    String transactionFee = MessagingOptionsEditDialog.this.transactionFeeTextField.getText();
 
                     if ((!MessagingOptionsEditDialog.this.verifyNumericField("amount to send", amountToSend)) ||
                             (!MessagingOptionsEditDialog.this.verifyNumericField("transaction fee", transactionFee))) {

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingOptionsEditDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingOptionsEditDialog.java
@@ -106,8 +106,8 @@ public class MessagingOptionsEditDialog
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                    String amountToSend = MessagingOptionsEditDialog.this.amountTextField.getText();
-                    String transactionFee = MessagingOptionsEditDialog.this.transactionFeeTextField.getText();
+                    String amountToSend = Util.removeUTF8BOM(MessagingOptionsEditDialog.this.amountTextField.getText());
+                    String transactionFee = Util.removeUTF8BOM(MessagingOptionsEditDialog.this.transactionFeeTextField.getText());
 
                     if ((!MessagingOptionsEditDialog.this.verifyNumericField("amount to send", amountToSend)) ||
                             (!MessagingOptionsEditDialog.this.verifyNumericField("transaction fee", transactionFee))) {

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingPanel.java
@@ -8,6 +8,7 @@ import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller.*;
 import org.btcprivate.wallets.fullnode.daemon.DataGatheringThread;
 import org.btcprivate.wallets.fullnode.ui.SendCashPanel;
 import org.btcprivate.wallets.fullnode.ui.WalletTabPanel;
+import org.btcprivate.wallets.fullnode.ui.WalletTextArea;
 import org.btcprivate.wallets.fullnode.util.Log;
 
 import javax.swing.*;
@@ -52,7 +53,7 @@ public class MessagingPanel
     private JLabel conversationLabel;
     private JTextPane conversationTextPane;
 
-    private JTextArea    writeMessageTextArea;
+    private WalletTextArea    writeMessageTextArea;
     private JButton      sendButton;
     private JLabel       sendResultLabel;
     private JProgressBar sendMessageProgressBar;
@@ -128,7 +129,7 @@ public class MessagingPanel
         this.add(writeAndSendPanel, BorderLayout.SOUTH);
 
         JPanel writePanel = new JPanel(new BorderLayout(0, 0));
-        this.writeMessageTextArea = new JTextArea(3, 50);
+        this.writeMessageTextArea = new WalletTextArea(3, 50);
         this.writeMessageTextArea.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
         this.writeMessageTextArea.setLineWrap(true);
         writePanel.add(
@@ -1087,7 +1088,7 @@ public class MessagingPanel
         // Get the text to send as a message
         if (textToSend == null)
         {
-            textToSend = Util.removeUTF8BOM(this.writeMessageTextArea.getText());
+            textToSend = this.writeMessageTextArea.getText();
         }
 
         if (textToSend.length() <= 0)
@@ -1957,7 +1958,7 @@ public class MessagingPanel
 
             if (ipfsLink != null)
             {
-                String oldText = Util.removeUTF8BOM(this.writeMessageTextArea.getText());
+                String oldText = this.writeMessageTextArea.getText();
                 oldText = oldText != null ? oldText : "";
 
                 this.writeMessageTextArea.setText(oldText + "\n" + ipfsLink);

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/MessagingPanel.java
@@ -1087,7 +1087,7 @@ public class MessagingPanel
         // Get the text to send as a message
         if (textToSend == null)
         {
-            textToSend = this.writeMessageTextArea.getText();
+            textToSend = Util.removeUTF8BOM(this.writeMessageTextArea.getText());
         }
 
         if (textToSend.length() <= 0)
@@ -1957,7 +1957,7 @@ public class MessagingPanel
 
             if (ipfsLink != null)
             {
-                String oldText = this.writeMessageTextArea.getText();
+                String oldText = Util.removeUTF8BOM(this.writeMessageTextArea.getText());
                 oldText = oldText != null ? oldText : "";
 
                 this.writeMessageTextArea.setText(oldText + "\n" + ipfsLink);

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/OwnIdentityEditDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/OwnIdentityEditDialog.java
@@ -2,6 +2,7 @@ package org.btcprivate.wallets.fullnode.messaging;
 
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.StatusUpdateErrorReporter;
+import org.btcprivate.wallets.fullnode.util.Util;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -66,7 +67,7 @@ public class OwnIdentityEditDialog
                 try
                 {
                     // Check for validity and save the data - T/Z addresses are not changed!
-                    String nick = OwnIdentityEditDialog.this.nicknameTextField.getText();
+                    String nick = Util.removeUTF8BOM(OwnIdentityEditDialog.this.nicknameTextField.getText());
                     if ((nick == null) || nick.trim().length() <= 0)
                     {
                         JOptionPane.showMessageDialog(
@@ -80,14 +81,14 @@ public class OwnIdentityEditDialog
 
                     // Save all identity fields from the text fields
                     MessagingIdentity id = OwnIdentityEditDialog.this.identity;
-                    id.setNickname(OwnIdentityEditDialog.this.nicknameTextField.getText());
-                    id.setFirstname(OwnIdentityEditDialog.this.firstnameTextField.getText());
-                    id.setMiddlename(OwnIdentityEditDialog.this.middlenameTextField.getText());
-                    id.setSurname(OwnIdentityEditDialog.this.surnameTextField.getText());
-                    id.setEmail(OwnIdentityEditDialog.this.emailTextField.getText());
-                    id.setStreetaddress(OwnIdentityEditDialog.this.streetaddressTextField.getText());
-                    id.setFacebook(OwnIdentityEditDialog.this.facebookTextField.getText());
-                    id.setTwitter(OwnIdentityEditDialog.this.twitterTextField.getText());
+                    id.setNickname(Util.removeUTF8BOM(OwnIdentityEditDialog.this.nicknameTextField.getText()));
+                    id.setFirstname(Util.removeUTF8BOM(OwnIdentityEditDialog.this.firstnameTextField.getText()));
+                    id.setMiddlename(Util.removeUTF8BOM(OwnIdentityEditDialog.this.middlenameTextField.getText()));
+                    id.setSurname(Util.removeUTF8BOM(OwnIdentityEditDialog.this.surnameTextField.getText()));
+                    id.setEmail(Util.removeUTF8BOM(OwnIdentityEditDialog.this.emailTextField.getText()));
+                    id.setStreetaddress(Util.removeUTF8BOM(OwnIdentityEditDialog.this.streetaddressTextField.getText()));
+                    id.setFacebook(Util.removeUTF8BOM(OwnIdentityEditDialog.this.facebookTextField.getText()));
+                    id.setTwitter(Util.removeUTF8BOM(OwnIdentityEditDialog.this.twitterTextField.getText()));
 
                     // Save the identity
                     OwnIdentityEditDialog.this.storage.updateOwnIdentity(id);

--- a/src/main/java/org/btcprivate/wallets/fullnode/messaging/OwnIdentityEditDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/messaging/OwnIdentityEditDialog.java
@@ -67,7 +67,7 @@ public class OwnIdentityEditDialog
                 try
                 {
                     // Check for validity and save the data - T/Z addresses are not changed!
-                    String nick = Util.removeUTF8BOM(OwnIdentityEditDialog.this.nicknameTextField.getText());
+                    String nick = OwnIdentityEditDialog.this.nicknameTextField.getText();
                     if ((nick == null) || nick.trim().length() <= 0)
                     {
                         JOptionPane.showMessageDialog(
@@ -81,14 +81,14 @@ public class OwnIdentityEditDialog
 
                     // Save all identity fields from the text fields
                     MessagingIdentity id = OwnIdentityEditDialog.this.identity;
-                    id.setNickname(Util.removeUTF8BOM(OwnIdentityEditDialog.this.nicknameTextField.getText()));
-                    id.setFirstname(Util.removeUTF8BOM(OwnIdentityEditDialog.this.firstnameTextField.getText()));
-                    id.setMiddlename(Util.removeUTF8BOM(OwnIdentityEditDialog.this.middlenameTextField.getText()));
-                    id.setSurname(Util.removeUTF8BOM(OwnIdentityEditDialog.this.surnameTextField.getText()));
-                    id.setEmail(Util.removeUTF8BOM(OwnIdentityEditDialog.this.emailTextField.getText()));
-                    id.setStreetaddress(Util.removeUTF8BOM(OwnIdentityEditDialog.this.streetaddressTextField.getText()));
-                    id.setFacebook(Util.removeUTF8BOM(OwnIdentityEditDialog.this.facebookTextField.getText()));
-                    id.setTwitter(Util.removeUTF8BOM(OwnIdentityEditDialog.this.twitterTextField.getText()));
+                    id.setNickname(OwnIdentityEditDialog.this.nicknameTextField.getText());
+                    id.setFirstname(OwnIdentityEditDialog.this.firstnameTextField.getText());
+                    id.setMiddlename(OwnIdentityEditDialog.this.middlenameTextField.getText());
+                    id.setSurname(OwnIdentityEditDialog.this.surnameTextField.getText());
+                    id.setEmail(OwnIdentityEditDialog.this.emailTextField.getText());
+                    id.setStreetaddress(OwnIdentityEditDialog.this.streetaddressTextField.getText());
+                    id.setFacebook(OwnIdentityEditDialog.this.facebookTextField.getText());
+                    id.setTwitter(OwnIdentityEditDialog.this.twitterTextField.getText());
 
                     // Save the identity
                     OwnIdentityEditDialog.this.storage.updateOwnIdentity(id);

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordDialog.java
@@ -4,6 +4,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import org.btcprivate.wallets.fullnode.ui.WalletPasswordField;
 import org.btcprivate.wallets.fullnode.util.Util;
 
 
@@ -19,7 +20,7 @@ public class PasswordDialog
     protected String  password    = null;
 
     protected JLabel     passwordLabel = null;
-    protected JTextField passwordField = null;
+    protected WalletPasswordField passwordField = null;
 
     protected JLabel upperLabel;
     protected JLabel lowerLabel;
@@ -51,7 +52,7 @@ public class PasswordDialog
 
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         tempPanel.add(passwordLabel = new JLabel("Password: "));
-        tempPanel.add(passwordField = new JPasswordField(30));
+        tempPanel.add(passwordField = new WalletPasswordField(30));
         controlsPanel.add(tempPanel);
 
         dividerLabel = new JLabel("   ");
@@ -114,7 +115,7 @@ public class PasswordDialog
 
     protected void processOK()
     {
-        String pass = Util.removeUTF8BOM(PasswordDialog.this.passwordField.getText());
+        String pass = PasswordDialog.this.passwordField.getText();
 
         if ((pass == null) || (pass.trim().length() <= 0))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordDialog.java
@@ -4,6 +4,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import org.btcprivate.wallets.fullnode.util.Util;
 
 
 /**
@@ -113,7 +114,7 @@ public class PasswordDialog
 
     protected void processOK()
     {
-        String pass = PasswordDialog.this.passwordField.getText();
+        String pass = Util.removeUTF8BOM(PasswordDialog.this.passwordField.getText());
 
         if ((pass == null) || (pass.trim().length() <= 0))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordEncryptionDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordEncryptionDialog.java
@@ -7,6 +7,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
+import org.btcprivate.wallets.fullnode.ui.WalletPasswordField;
 import org.btcprivate.wallets.fullnode.util.Util;
 
 
@@ -18,7 +19,7 @@ import org.btcprivate.wallets.fullnode.util.Util;
 public class PasswordEncryptionDialog
         extends PasswordDialog
 {
-    protected JTextField passwordConfirmationField = null;
+    protected WalletPasswordField passwordConfirmationField = null;
 
     public PasswordEncryptionDialog(JFrame parent)
     {
@@ -31,7 +32,7 @@ public class PasswordEncryptionDialog
 
         JLabel confLabel = new JLabel("Confirmation: ");
         this.freeSlotPanel.add(confLabel);
-        this.freeSlotPanel.add(passwordConfirmationField = new JPasswordField(30));
+        this.freeSlotPanel.add(passwordConfirmationField = new WalletPasswordField(30));
         this.passwordLabel.setPreferredSize(confLabel.getPreferredSize());
 
         JLabel dividerLabel = new JLabel("   ");
@@ -46,8 +47,8 @@ public class PasswordEncryptionDialog
 
     protected void processOK()
     {
-        String password     = Util.removeUTF8BOM(this.passwordField.getText());
-        String confirmation = Util.removeUTF8BOM(this.passwordConfirmationField.getText());
+        String password     = this.passwordField.getText();
+        String confirmation = this.passwordConfirmationField.getText();
 
         if (password == null)
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordEncryptionDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/PasswordEncryptionDialog.java
@@ -7,6 +7,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
+import org.btcprivate.wallets.fullnode.util.Util;
 
 
 /**
@@ -45,8 +46,8 @@ public class PasswordEncryptionDialog
 
     protected void processOK()
     {
-        String password     = this.passwordField.getText();
-        String confirmation = this.passwordConfirmationField.getText();
+        String password     = Util.removeUTF8BOM(this.passwordField.getText());
+        String confirmation = Util.removeUTF8BOM(this.passwordConfirmationField.getText());
 
         if (password == null)
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
@@ -44,6 +44,7 @@ import org.btcprivate.wallets.fullnode.daemon.DataGatheringThread;
 import org.btcprivate.wallets.fullnode.util.BackupTracker;
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.StatusUpdateErrorReporter;
+import org.btcprivate.wallets.fullnode.util.Util;
 
 
 /**
@@ -367,16 +368,16 @@ public class SendCashPanel
         }
 
         final String sourceAddress = this.lastAddressBalanceData[this.balanceAddressCombo.getSelectedIndex()][1];
-        final String destinationAddress = this.destinationAddressField.getText();
-        final String memo = this.destinationMemoField.getText();
-        final String amount = this.destinationAmountField.getText();
-        final String fee = this.transactionFeeField.getText();
+        final String destinationAddress = Util.removeUTF8BOM(this.destinationAddressField.getText());
+        final String memo = Util.removeUTF8BOM(this.destinationMemoField.getText());
+        final String amount = Util.removeUTF8BOM(this.destinationAmountField.getText());
+        final String fee = Util.removeUTF8BOM(this.transactionFeeField.getText());
 
         // Verify general correctness.
         // https://github.com/BTCPrivate/trezor-common/blob/08fe85ad07bbbdc25cc83ffae8be7aff89245594/coins.json#L575 
         // B Addresses are 35 chars (b1, bx)
         // Z Addresses are 95 chars (zk)
-        // base58check encoded
+        // base58check encoded		
 
         // Prevent accidental sending to non-BTCP addresses (as seems to be supported by daemon)
         if (!installationObserver.isOnTestNet())

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SendCashPanel.java
@@ -45,6 +45,7 @@ import org.btcprivate.wallets.fullnode.util.BackupTracker;
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.StatusUpdateErrorReporter;
 import org.btcprivate.wallets.fullnode.util.Util;
+import org.btcprivate.wallets.fullnode.ui.WalletTextField;
 
 
 /**
@@ -66,10 +67,10 @@ public class SendCashPanel
     private String[]   comboBoxItems           = null;
     private DataGatheringThread<String[][]> addressBalanceGatheringThread = null;
 
-    private JTextField destinationAddressField = null;
-    private JTextField destinationAmountField  = null;
-    private JTextField destinationMemoField    = null;
-    private JTextField transactionFeeField     = null;
+    private WalletTextField destinationAddressField = null;
+    private WalletTextField destinationAmountField  = null;
+    private WalletTextField destinationMemoField    = null;
+    private WalletTextField transactionFeeField     = null;
 
     private JButton    sendButton              = null;
 
@@ -124,7 +125,7 @@ public class SendCashPanel
         tempPanel.add(new JLabel("Destination address:"));
         sendCashPanel.add(tempPanel);
 
-        destinationAddressField = new JTextField(73);
+        destinationAddressField = new WalletTextField(73);
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         tempPanel.add(destinationAddressField);
         sendCashPanel.add(tempPanel);
@@ -141,7 +142,7 @@ public class SendCashPanel
                         "</span>  "));
         sendCashPanel.add(tempPanel);
 
-        destinationMemoField = new JTextField(73);
+        destinationMemoField = new WalletTextField(73);
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         tempPanel.add(destinationMemoField);
         sendCashPanel.add(tempPanel);
@@ -155,7 +156,7 @@ public class SendCashPanel
         JPanel amountPanel = new JPanel(new BorderLayout());
         amountPanel.add(new JLabel("Amount to send:"), BorderLayout.NORTH);
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        tempPanel.add(destinationAmountField = new JTextField(13));
+        tempPanel.add(destinationAmountField = new WalletTextField(13));
         destinationAmountField.setHorizontalAlignment(SwingConstants.RIGHT);
         tempPanel.add(new JLabel(" BTCP    "));
         amountPanel.add(tempPanel, BorderLayout.SOUTH);
@@ -163,7 +164,7 @@ public class SendCashPanel
         JPanel feePanel = new JPanel(new BorderLayout());
         feePanel.add(new JLabel("Transaction fee:"), BorderLayout.NORTH);
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        tempPanel.add(transactionFeeField = new JTextField(13));
+        tempPanel.add(transactionFeeField = new WalletTextField(13));
         transactionFeeField.setText("0.0001"); // Default value
         transactionFeeField.setHorizontalAlignment(SwingConstants.RIGHT);
         tempPanel.add(new JLabel(" BTCP"));
@@ -368,10 +369,10 @@ public class SendCashPanel
         }
 
         final String sourceAddress = this.lastAddressBalanceData[this.balanceAddressCombo.getSelectedIndex()][1];
-        final String destinationAddress = Util.removeUTF8BOM(this.destinationAddressField.getText());
-        final String memo = Util.removeUTF8BOM(this.destinationMemoField.getText());
-        final String amount = Util.removeUTF8BOM(this.destinationAmountField.getText());
-        final String fee = Util.removeUTF8BOM(this.transactionFeeField.getText());
+        final String destinationAddress = this.destinationAddressField.getText();
+        final String memo = this.destinationMemoField.getText();
+        final String amount = this.destinationAmountField.getText();
+        final String fee = this.transactionFeeField.getText();
 
         // Verify general correctness.
         // https://github.com/BTCPrivate/trezor-common/blob/08fe85ad07bbbdc25cc83ffae8be7aff89245594/coins.json#L575 

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SingleKeyImportDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SingleKeyImportDialog.java
@@ -2,6 +2,7 @@ package org.btcprivate.wallets.fullnode.ui;
 
 import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller;
 import org.btcprivate.wallets.fullnode.daemon.BTCPClientCaller.WalletCallException;
+import org.btcprivate.wallets.fullnode.ui.WalletTextField;
 import org.btcprivate.wallets.fullnode.util.Log;
 import org.btcprivate.wallets.fullnode.util.Util;
 
@@ -24,7 +25,7 @@ public class SingleKeyImportDialog
     protected String  key    = null;
 
     protected JLabel     keyLabel = null;
-    protected JTextField keyField = null;
+    protected WalletTextField keyField = null;
 
     protected JLabel upperLabel;
     protected JLabel lowerLabel;
@@ -64,7 +65,7 @@ public class SingleKeyImportDialog
 
         tempPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         tempPanel.add(keyLabel = new JLabel("Key: "));
-        tempPanel.add(keyField = new JTextField(60));
+        tempPanel.add(keyField = new WalletTextField(60));
         controlsPanel.add(tempPanel);
 
         dividerLabel = new JLabel("   ");
@@ -133,7 +134,7 @@ public class SingleKeyImportDialog
 
     protected void processOK()
     {
-        final String key = Util.removeUTF8BOM(SingleKeyImportDialog.this.keyField.getText());
+        final String key = SingleKeyImportDialog.this.keyField.getText();
 
         if ((key == null) || (key.trim().length() <= 0))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/SingleKeyImportDialog.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/SingleKeyImportDialog.java
@@ -133,7 +133,7 @@ public class SingleKeyImportDialog
 
     protected void processOK()
     {
-        final String key = SingleKeyImportDialog.this.keyField.getText();
+        final String key = Util.removeUTF8BOM(SingleKeyImportDialog.this.keyField.getText());
 
         if ((key == null) || (key.trim().length() <= 0))
         {

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/WalletPasswordField.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/WalletPasswordField.java
@@ -1,0 +1,19 @@
+package org.btcprivate.wallets.fullnode.ui;
+
+import javax.swing.*;
+import org.btcprivate.wallets.fullnode.util.Util;
+	
+public class WalletPasswordField
+        extends JPasswordField
+{
+    public WalletPasswordField(int columns)
+    {
+        super(columns);
+    }
+        
+    public String getText()
+    {
+    	return Util.removeUTF8BOM(super.getText());
+    }
+
+} // End class

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/WalletTextArea.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/WalletTextArea.java
@@ -1,0 +1,19 @@
+package org.btcprivate.wallets.fullnode.ui;
+
+import javax.swing.*;
+import org.btcprivate.wallets.fullnode.util.Util;
+	
+public class WalletTextArea
+        extends JTextArea
+{
+    public WalletTextArea(int rows, int columns)
+    {
+        super(rows, columns);
+    }
+        
+    public String getText()
+    {
+    	return Util.removeUTF8BOM(super.getText());
+    }
+
+} // End class

--- a/src/main/java/org/btcprivate/wallets/fullnode/ui/WalletTextField.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/ui/WalletTextField.java
@@ -1,0 +1,19 @@
+package org.btcprivate.wallets.fullnode.ui;
+
+import javax.swing.*;
+import org.btcprivate.wallets.fullnode.util.Util;
+	
+public class WalletTextField
+        extends JTextField
+{
+    public WalletTextField(int columns)
+    {
+        super(columns);
+    }
+        
+    public String getText()
+    {
+    	return Util.removeUTF8BOM(super.getText());
+    }
+
+} // End class

--- a/src/main/java/org/btcprivate/wallets/fullnode/util/Util.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/util/Util.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.btcprivate.wallets.fullnode.util.Util;
 
 /**
  * Utilities - generally reusable across classes.
@@ -401,5 +402,14 @@ public class Util
                 oRAF.close();
             }
         }
+    }
+    
+    public static final String UTF8_BOM = "\uFEFF";
+
+	public static String removeUTF8BOM(String s) {
+    	if (s.startsWith(UTF8_BOM)) {
+        	s = s.substring(1);
+    	}
+    	return s;
     }
 }

--- a/src/main/java/org/btcprivate/wallets/fullnode/util/Util.java
+++ b/src/main/java/org/btcprivate/wallets/fullnode/util/Util.java
@@ -406,10 +406,8 @@ public class Util
     
     public static final String UTF8_BOM = "\uFEFF";
 
-	public static String removeUTF8BOM(String s) {
-    	if (s.startsWith(UTF8_BOM)) {
-        	s = s.substring(1);
-    	}
-    	return s;
+	public static String removeUTF8BOM(String s)
+	{
+    	return (s.startsWith(UTF8_BOM) ? s.substring(1) : s);
     }
 }


### PR DESCRIPTION
When copying a text value (e.g. public address or private key) out of Electrum BTCP on the Mac platform, the UTF8 BOM is included in the string value- which can present a problem for Java-based apps which do not expect the presence of a BOM in UTF8 data. These code changes strip out the UTF8 BOM out of string values whenever they are captured from a text field via getText() so that addresses for sending as well as private keys for importing are properly recognized and processed. Fixes #27 and fixes BTCPrivate/electrum-btcp#56